### PR TITLE
Update AzuraCast Contact Information

### DIFF
--- a/tools.html
+++ b/tools.html
@@ -40,7 +40,7 @@ schedulers or web integration. Feel free to
 <li>
 <a href="http://www.sourcefabric.org/en/airtime/" target="_blank">Airtime</a> lets you take total control of your radio station via the web with intelligent archive management, powerful search, an easy playlist builder, a simple scheduling calendar and rock-solid automated playout. Those who need a little extra will love the ability to manage staff, record and rebroadcast a live show, upload to SoundCloud automatically, stream to Icecast and display programme information via Airtime's website widgets. It is written in Python/Django.</li>
 <li>
-<a href="https://github.com/SlvrEagle23/AzuraCast">AzuraCast</a> is a lightweight “all-in-one” turnkey radio station management kit, with modular support for radio backends and frontends.</li>
+<a href="https://www.azuracast.com">AzuraCast</a> is a lightweight, "all-in-one" turnkey web radio management suite. It includes all of the software necessary to operate your station, and can be installed from scratch on Ubuntu servers or run anywhere Docker is supported. Its web interface is written in PHP.</li>
 <li>
 <a href="https://github.com/kenrestivo/bufferplot">Bufferplot</a> displays graphically the buffer levels from logs.</li>
 <li>


### PR DESCRIPTION
Hello! AzuraCast recently launched a more powerful and better-documented homepage. Also, in the intervening time since this page was last updated, the project has moved to an independent GitHub organization, so the old URL needed updating in any case. I also clarified the description text to make it line up better with other projects described on the page.